### PR TITLE
Add an option to show a cancel button.

### DIFF
--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -34,3 +34,15 @@ It can be changed by setting `textarea-placeholder` or `textareaPlaceholder` pro
 The text of submit button. the default is `Send Feedback`.
 It can be changed by setting `button-label` or `buttonLabel` property.
 
+
+### Cancel button
+If you use this element as a modal and wish to have a cancel button in
+the UI set the `showCancelButton` property to true or use `show-cancel-button` attribute.
+Then, when a user clicks the cancel button, we will emit a `feedback-cancelled`
+event so you can update your UI accordingly. See the [events section](./index.md#events)
+on how to setup a event listener to catch the event.
+
+### Cancel Button Label
+
+The text of cancel button, the default is `Cancel`.
+It can be changed by setting `cancel-label` or `cancelButton` property.

--- a/docs/index.md
+++ b/docs/index.md
@@ -63,4 +63,10 @@ sendFeedback.addEventListener('<event>', ...);
 This event is only triggered when feedback is submitted, meaning when a reporter
 is done executing without throwing an error.
 
+#### `feedback-cancelled`
+
+This even triggered when the user hits the cancel button. By default
+this button is now shown, you need to enable it if you want to use it.
+See [the docs on it](./customizing.md#cancel-button-label) for more info!
+
 

--- a/example-app/send-feedback.html
+++ b/example-app/send-feedback.html
@@ -16,6 +16,7 @@
         <option value="textarea-label">Customize Textarea label</option>
         <option value="textarea-placeholder">Customize Textarea placeholder</option>
         <option value="button-label">Customize Button label</option>
+        <option value="closebtn-label">Customize Close Button label</option>
       </select>
       <input type="text" class="customize-value">
       <button class="customize-element">Customize</button>

--- a/lib/index.js
+++ b/lib/index.js
@@ -42,7 +42,9 @@ class SendFeedback extends HTMLElement {
       'title-placeholder',
       'textarea-label',
       'textarea-placeholder',
-      'button-label'
+      'button-label',
+      'cancel-label',
+      'show-cancel-button'
     ];
   }
 
@@ -60,16 +62,23 @@ class SendFeedback extends HTMLElement {
     this._titleLabel = shadowRoot.querySelector('label');
     this._titleInput = shadowRoot.querySelector('input');
     this._button = shadowRoot.querySelector('button');
+    this._cancel = shadowRoot.querySelector('#cancel');
     this._loader = shadowRoot.querySelector('.loader');
 
     this._textarea.addEventListener('input', this._recheckErrorClass);
     this._titleInput.addEventListener('input', this._recheckErrorClass);
     this._button.addEventListener('click', this._onSubmitFeedback.bind(this));
 
-    this.feedbackSubmittedEvent = new Event('feedback-submitted', {
+    const eventOptions = {
       bubbles: false,
       cancelable: false,
-      composed: true
+      composed: true,
+    };
+
+    this.feedbackSubmittedEvent = new Event('feedback-submitted', eventOptions);
+    this.feedbackCancelledEvent = new Event('feedback-cancelled', eventOptions);
+    this._cancel.addEventListener('click', () => {
+      this.dispatchEvent(this.feedbackCancelledEvent);
     });
 
     this.attr.createAttrToPropBridge(this._attributesToObserve);
@@ -136,7 +145,8 @@ class SendFeedback extends HTMLElement {
       'title-placeholder': 'Enter a title',
       'textarea-label': 'Send us your experience with this app:',
       'textarea-placeholder': 'Write your feedback...',
-      'button-label': 'Send Feedback'
+      'button-label': 'Send Feedback',
+      'cancel-label': 'Cancel'
     };
 
     attr.id++;
@@ -189,13 +199,24 @@ class SendFeedback extends HTMLElement {
   _updateContents(updatedAttr, _old, _new) {
     const selectors = {
       title: this._title,
+      textarea: this._textarea,
       'title-label': this._titleLabel,
       'title-placeholder': this._titleInput,
       'textarea-label': this._textareaLabel,
       'textarea-placeholder': this._textarea,
-      textarea: this._textarea,
-      'button-label': this._button
+      'button-label': this._button,
+      'cancel-label': this._cancel,
     };
+
+    if (updatedAttr == 'show-cancel-button') {
+      if (_new == true || _new == 'true') {
+        this._cancel.classList.add('show');
+      } else {
+        this._cancel.classList.remove('show');
+      }
+
+      return;
+    }
 
     const el = selectors[updatedAttr];
     if (updatedAttr.includes('placeholder')) {
@@ -215,13 +236,14 @@ class SendFeedback extends HTMLElement {
   }
 
   showLoader() {
-    const { _button, _loader } = this;
+    const { _button, _cancel, _loader } = this;
     _button.classList.add('hide');
-    _loader.classList.add('show');
+    _cancel.classList.add('hide');
+    _loader.classList.remove('show');
   }
 
   hideLoader(error = false) {
-    const { _button, _loader, loaderTexts } = this;
+    const { _button, _loader, _cancel, showCancelButton, loaderTexts } = this;
     _loader.classList.add('stop');
     if (error) { _loader.classList.add('error'); }
     _loader.innerHTML = error ? loaderTexts.error : loaderTexts.sucess;
@@ -232,6 +254,10 @@ class SendFeedback extends HTMLElement {
       _loader.classList.remove('error');
       _loader.innerHTML = '';
       _button.classList.remove('hide');
+      console.log('Should show cancel button:', showCancelButton);
+      if (showCancelButton) {
+        _cancel.classList.add("show");
+      }
     }, error ? 3000 : 2000);
   }
 

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -72,6 +72,24 @@ templates.add('send-feedback', `
     padding: 13px 14px;
   }
 
+  #cancel {
+    margin-left: -3px;
+    display: none;
+    border: 1px solid black;
+    background-color: white;
+    color: black;
+  }
+
+  #cancel.show {
+    display: initial;
+  }
+
+  #cancel:hover {
+    color: #D9534F;
+    border-color: #D9534F;
+    background-color: white;
+  }
+
   .hide {
     transition: initial;
     opacity: 0;
@@ -159,6 +177,7 @@ templates.add('send-feedback-content', `
   
   <div>
     <button role="button" aria-label="Send">{{ button-label }}</button>
+    <button role="button" id="cancel" aria-label="Cancel">{{ cancel-label }}</button>
     <div class="loader"></div>
   </div>
 </section>


### PR DESCRIPTION
So @priyank-p I have added a non-working(only HTML & CSS) close button to the form. 

![Screenshot from 2020-05-13 22-03-55](https://user-images.githubusercontent.com/48093317/81840094-19c89500-9566-11ea-9b95-af138cf87c82.png)

**Things that Need Attention**:-
1. I would love to resolve the buttons(Send Feedback & Close) which are on different lines, I tried `display: inline-block;` but for some reason, It's not working; I'll surely find a fix for that in some time.

2. The animation over the close button is not working and that's pretty much ok according to me since that can really distinguish it from the `Send Feedback` button but nonetheless let me know your thoughts on this.

3. Also, the fact that the `Customize Close Button label` is not changing the text in the close button I am sure it's due to the absence of middleware (JS) in `index.js`.

That pretty much sums it up!

_**My Opinion**_

I would really like to help you with the handling and working of the close button; if you could guide me. This way I can surely improve my JS knowledge.

**Suggestions/Recommendations**
I would like to suggest a dialog box that gives a warning if you click the close button when there is some text written in the `text-area`, which could say something like "_Text Area/Title Area is not empty. Would you still like to continue exiting the Feedback Form?_". This message dialog can have two buttons "Yes" & "No". If no is clicked then the dialog is closed and the user can continue writing the text area. 