### PR TITLE
Removed deprecated function 

### DIFF
--- a/test/basics.test.js
+++ b/test/basics.test.js
@@ -100,7 +100,7 @@ describe('send-feedback', () => {
         assert.deepStrictEqual(feedback[prop], expectedFeedback[prop]);
       }
 
-      assert.deepEqual(customData, data);
+      assert.deepStrictEqual(customData, data);
     }
 
     sendFeedback.addEventListener('feedback-submitted', () => {


### PR DESCRIPTION
The function `assert.deepEqual` is deprecated since v10.0.0 hence `assert.deepStrictEqual` or `assert.strict.deepEqual` should be used.